### PR TITLE
App Index recalculation is executed even if parameter permits this

### DIFF
--- a/tasks/lib/filestore.js
+++ b/tasks/lib/filestore.js
@@ -193,6 +193,7 @@ FileStore.prototype.calcAppIndex = function (fnCallback) {
     if (!this._oOptions.ui5.calc_appindex) {
         // option to recalculate the application index is not enabled - simply fire the callback
         fnCallback(null, null);
+        return;
     }
 
     // create the URL for appindex recalculation


### PR DESCRIPTION
`fnCallback` is executed correctly but code flow is resumed some time later on line 199 (even if `calc_appindex` was not set or set to `false`). So the app index is always recalculated no matter to the value of the parameter is. As another result of that `fnCallback` gets executed twice.